### PR TITLE
support custom 404 page

### DIFF
--- a/wildcard_router.go
+++ b/wildcard_router.go
@@ -30,8 +30,8 @@ func (w *WildcardRouter) AddHandler(handler http.Handler) {
 	w.handlers = append(w.handlers, handler)
 }
 
-// NotFoundHandler will set handler to handle 404
-func (w *WildcardRouter) NotFoundHandler(handler http.HandlerFunc) {
+// NoRoute will set handler to handle 404
+func (w *WildcardRouter) NoRoute(handler http.HandlerFunc) {
 	w.notFoundHandler = handler
 }
 

--- a/wildcard_router_test.go
+++ b/wildcard_router_test.go
@@ -61,6 +61,7 @@ func (b ModuleB) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func init() {
 	router := gin.Default()
+
 	router.GET("/", func(c *gin.Context) {
 		c.Writer.Write([]byte("Gin Handle HomePage"))
 	})
@@ -71,6 +72,9 @@ func init() {
 	wildcardRouter.AddHandler(ModuleBeforeA{})
 	wildcardRouter.AddHandler(ModuleA{})
 	wildcardRouter.AddHandler(ModuleB{})
+	wildcardRouter.NotFoundHandler(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("Sorry, this page was gone!"))
+	})
 }
 
 type WildcardRouterTestCase struct {
@@ -84,7 +88,7 @@ func TestWildcardRouter(t *testing.T) {
 		{URL: "/", ExpectStatusCode: 200, ExpectHasContent: "Gin Handle HomePage"},
 		{URL: "/module_a", ExpectStatusCode: 200, ExpectHasContent: "Module A handled"},
 		{URL: "/module_b", ExpectStatusCode: 200, ExpectHasContent: "Module B handled"},
-		{URL: "/module_x", ExpectStatusCode: 404, ExpectHasContent: "404 page not found\n"},
+		{URL: "/module_x", ExpectStatusCode: 404, ExpectHasContent: "Sorry, this page was gone!"},
 		{URL: "/module_a0", ExpectStatusCode: 200, ExpectHasContent: "Module Before A handled"},
 	}
 

--- a/wildcard_router_test.go
+++ b/wildcard_router_test.go
@@ -72,7 +72,7 @@ func init() {
 	wildcardRouter.AddHandler(ModuleBeforeA{})
 	wildcardRouter.AddHandler(ModuleA{})
 	wildcardRouter.AddHandler(ModuleB{})
-	wildcardRouter.NotFoundHandler(func(w http.ResponseWriter, req *http.Request) {
+	wildcardRouter.NoRoute(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("Sorry, this page was gone!"))
 	})
 }


### PR DESCRIPTION
Due to wildcard will hold all handlers that if status code is 404 and return default 404 at the end, so it is impossible to add your custom 404 page.

![image](https://cloud.githubusercontent.com/assets/147775/25417005/b810f9e8-2a73-11e7-8588-265d875b74b7.png)

if you write you custom 404, e.g. `ginRouter.noRoute`, since the status code is 404, so isProcessed will be false, then `wildcardRouterWriter.reset()` will be call and status code will became 0.

This PR will add `wildcardRouter.NotFoundHandler` to support custom 404 page.