### PR TITLE
fix content type always empty

### DIFF
--- a/wildcard_router.go
+++ b/wildcard_router.go
@@ -43,6 +43,7 @@ func (w *WildcardRouter) Use(middleware func(writer http.ResponseWriter, request
 // ServeHTTP serve http for wildcard router
 func (w *WildcardRouter) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	wildcardRouterWriter := &WildcardRouterWriter{writer, 0, false}
+	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	for _, middleware := range w.middlewares {
 		middleware(writer, req)
@@ -97,7 +98,6 @@ func (w *WildcardRouterWriter) Write(data []byte) (int, error) {
 
 func (w *WildcardRouterWriter) reset() {
 	w.skipNotFoundCheck = false
-	w.Header().Set("Content-Type", "")
 	w.status = 0
 }
 

--- a/wildcard_router.go
+++ b/wildcard_router.go
@@ -43,7 +43,6 @@ func (w *WildcardRouter) Use(middleware func(writer http.ResponseWriter, request
 // ServeHTTP serve http for wildcard router
 func (w *WildcardRouter) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	wildcardRouterWriter := &WildcardRouterWriter{writer, 0, false}
-	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	for _, middleware := range w.middlewares {
 		middleware(writer, req)
@@ -58,7 +57,6 @@ func (w *WildcardRouter) ServeHTTP(writer http.ResponseWriter, req *http.Request
 
 	wildcardRouterWriter.skipNotFoundCheck = true
 	if w.notFoundHandler != nil {
-		writer.WriteHeader(http.StatusNotFound)
 		w.notFoundHandler(writer, req)
 	} else {
 		http.NotFound(wildcardRouterWriter, req)
@@ -98,6 +96,7 @@ func (w *WildcardRouterWriter) Write(data []byte) (int, error) {
 
 func (w *WildcardRouterWriter) reset() {
 	w.skipNotFoundCheck = false
+	w.Header().Set("Content-Type", "")
 	w.status = 0
 }
 

--- a/wildcard_router_test.go
+++ b/wildcard_router_test.go
@@ -77,7 +77,9 @@ func init() {
 	wildcardRouter.AddHandler(ModuleA{})
 	wildcardRouter.AddHandler(ModuleB{})
 	wildcardRouter.NoRoute(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte("Sorry, this page was gone!"))
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("<h1>Sorry, this page was gone!</h1>"))
 	})
 }
 
@@ -93,7 +95,7 @@ func TestWildcardRouter(t *testing.T) {
 		{URL: "/", ExpectStatusCode: 200, ExpectHasContent: "Gin Handle HomePage", ExpectContentType: "text/gin"},
 		{URL: "/module_a", ExpectStatusCode: 200, ExpectHasContent: "Module A handled", ExpectContentType: "text/moduleA"},
 		{URL: "/module_b", ExpectStatusCode: 200, ExpectHasContent: "Module B handled", ExpectContentType: "text/moduleB"},
-		{URL: "/module_x", ExpectStatusCode: 404, ExpectHasContent: "Sorry, this page was gone!", ExpectContentType: "text/plain; charset=utf-8"},
+		{URL: "/module_x", ExpectStatusCode: 404, ExpectHasContent: "<h1>Sorry, this page was gone!</h1>", ExpectContentType: "text/html; charset=utf-8"},
 		{URL: "/module_a0", ExpectStatusCode: 200, ExpectHasContent: "Module Before A handled", ExpectContentType: "text/moduleBeforeA"},
 	}
 
@@ -110,7 +112,7 @@ func TestWildcardRouter(t *testing.T) {
 			hasError = true
 		}
 		if req.Header["Content-Type"][0] != testCase.ExpectContentType {
-			t.Errorf(color.RedString(fmt.Sprintf("WildcardRouter #%v: Expect request Content-Type is '%v', but got '%v'", i+1, testCase.ExpectContentType, req.Header["Content-Type"][0])))
+			t.Errorf(color.RedString(fmt.Sprintf("WildcardRouter #%v: Expect response Content-Type is '%v', but got '%v'", i+1, testCase.ExpectContentType, req.Header["Content-Type"][0])))
 			hasError = true
 		}
 		if !hasError {


### PR DESCRIPTION
* Fixed `Content-Type` in response header always empty due to 

```
func (w *WildcardRouterWriter) reset() {
	w.skipNotFoundCheck = false
	w.Header().Set("Content-Type", "")
	w.status = 0
}
```

but could remember why i add this before. However, added tests and seems work after remove this code.